### PR TITLE
enable mysql db provisioning

### DIFF
--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,4 +25,4 @@ appVersion: "5.7.0"
 
 dependencies:
   - name: mysql
-    version: 0.1.1
+    version: 0.1.2

--- a/charts/wordpress/charts/mysql/Chart.yaml
+++ b/charts/wordpress/charts/mysql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wordpress/charts/mysql/templates/deployment.yaml
+++ b/charts/wordpress/charts/mysql/templates/deployment.yaml
@@ -28,12 +28,26 @@ spec:
       labels:
         component: mysql
     spec:
+{{ if .Values.provisioning.url }}
+      initContainers:
+      - name: provision-sql
+        image: curlimages/curl
+        workingDir: /tmp
+        args:
+        - "{{ .Values.provisioning.url }}"
+        - "-odump.sql"
+        volumeMounts:
+        - name: sqldump
+          mountPath: /tmp
+{{ end }}
       containers:
       - name: mysql
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 3306
+        args:
+        - "--verbose"
         env:
         - name: MYSQL_RANDOM_ROOT_PASSWORD
           value: "yes"
@@ -62,7 +76,10 @@ spec:
           mountPath: /var/lib/mysql
         - name: config
           mountPath: /etc/mysql/conf.d
-          #subPath: docker.cnf
+{{ if .Values.provisioning.url }}
+        - name: sqldump
+          mountPath: /docker-entrypoint-initdb.d
+{{ end }}
 {{ if .Values.secretProvider }}
         - name: akv
           mountPath: /mnt/secrets
@@ -74,6 +91,10 @@ spec:
         - name: config
           configMap:
             name: {{ .Release.Name }}-docker.cnf
+{{ if .Values.provisioning.url }}
+        - name: sqldump
+          emptyDir: {}
+{{ end }}
 {{ if .Values.secretProvider }}
         - name: akv
           csi:

--- a/charts/wordpress/charts/mysql/values.yaml
+++ b/charts/wordpress/charts/mysql/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 #
+provisioning:
+  url: {}
+
 image:
   repository: "mysql"
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Add the possibility to load a MySQL dump-file on pod start, of course only when there isn't an active database